### PR TITLE
feat: 添加最新的 moveBlock API

### DIFF
--- a/src/api/server-api.ts
+++ b/src/api/server-api.ts
@@ -422,6 +422,13 @@ export async function deleteBlock(id) {
     return parseBody(request(url, { id }));
 }
 
+export async function moveBlock(id: string, previousID: string, parentID: string) {
+    let url = '/api/block/moveBlock';
+    return parseBody(
+        request(url, { id: id, previousID: previousID, parentID: parentID })
+    );
+}
+
 export async function getSysFonts() {
     let url = '/api/system/getSysFonts';
     return parseBody(request(url, null));


### PR DESCRIPTION
提供思源将在下个版本 2.8.4 发布的新 API moveBlock 的支持。

![image](https://user-images.githubusercontent.com/27268127/230786237-d1d9a902-843f-4378-b105-a6bb30259c3d.png)


https://github.com/siyuan-note/siyuan/blob/dev/API_zh_CN.md#%E7%A7%BB%E5%8A%A8%E5%9D%97