### PR TITLE
添加新api moveBlock

### DIFF
--- a/src/api/server-api.ts
+++ b/src/api/server-api.ts
@@ -422,6 +422,13 @@ export async function deleteBlock(id) {
     return parseBody(request(url, { id }));
 }
 
+export async function moveBlock(id: string, previousID: string, parentID: string) {
+    let url = '/api/block/moveBlock';
+    return parseBody(
+        request(url, { id: id, previousID: previousID, parentID: parentID })
+    );
+}
+
 export async function getSysFonts() {
     let url = '/api/system/getSysFonts';
     return parseBody(request(url, null));

--- a/type/siyuan.d.ts
+++ b/type/siyuan.d.ts
@@ -62,6 +62,7 @@ declare module 'siyuan/api/server-api' {
     export function appendBlock(parentID: any, dataType: any, data: any): Promise<any>;
     export function updateBlock(id: any, dataType: any, data: any): Promise<any>;
     export function deleteBlock(id: any): Promise<any>;
+    export function moveBlock(id: any, previousID: any, parentID: any): Promise<any>;
     export function getSysFonts(): Promise<any>;
     export function getFile(path: any): Promise<Response>;
     export function putFile(path: any, filedata: any, isDir?: boolean, modTime?: number): Promise<any>;


### PR DESCRIPTION
提供思源将在下个版本 2.8.4 发布的新 API moveBlock 的支持。

![image](https://user-images.githubusercontent.com/27268127/230786511-f4d2ac54-6475-4467-b56b-ae27165c3abb.png)

https://github.com/siyuan-note/siyuan/blob/dev/API_zh_CN.md#%E7%A7%BB%E5%8A%A8%E5%9D%97